### PR TITLE
onMoveShouldSetPanResponder should equal false

### DIFF
--- a/CarouselPager.js
+++ b/CarouselPager.js
@@ -99,7 +99,7 @@ export default class CarouselPager extends Component {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
       onStartShouldSetPanResponderCapture: (evt, gestureState) => false,
-      onMoveShouldSetPanResponder: (evt, gestureState) => true,
+      onMoveShouldSetPanResponder: (evt, gestureState) => false,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => false,
 
       onPanResponderGrant: (evt, gestureState) => {


### PR DESCRIPTION
When onMoveShouldSetPanResponder equals true, touchable elements placed inside of the carousel won't call onPress functions. While no solution is going to be perfect for everyone, I believe setting this to false is a good compromise for functionality.

Old behavior:
Users could swipe anywhere inside of the carousel to trigger the pan responder.

New behavior:
If a touchable element is inside of the carousel, swiping on it will trigger onPress and not the pan responder. Swiping everywhere else within the carousel will still trigger the pan responder.

EX Usage:

```
<View style={styles.main}>
        <CarouselPager initialPage={0} pageStyle={{backgroundColor: 'red', alignSelf: 'center'}}>
          <View style={styles.carouselView} key={'page0'}>
            <Card title="Individual Community" containerStyle={styles.card} >
              <Image source='./assets/single.png' style={styles.image} />
              <TouchableOpacity style={styles.createCommunityBtn} onPress={ () => this.doSomething() }>
                <View style={styles.createCommunityView}>
                  <Icon name='feather' type='material-community' color='#fff' size={30} />
                  <Text style={styles.createCommunityText}>Create Community</Text>
                </View>
              </TouchableOpacity>
            </Card>
          </View>
        </CarouselPager>
      </View>
```