### PR TITLE
Add animationDuration property for page transitions

### DIFF
--- a/CarouselPager.js
+++ b/CarouselPager.js
@@ -13,6 +13,7 @@ export default class CarouselPager extends Component {
     vertical: PropTypes.bool,
     blurredZoom: PropTypes.number,
     blurredOpacity: PropTypes.number,
+    animationDuration: PropTypes.number,
     containerPadding: PropTypes.number,
     pageSpacing: PropTypes.number,
     pageStyle: PropTypes.object,
@@ -25,6 +26,7 @@ export default class CarouselPager extends Component {
     initialPage: 0,
     blurredZoom: 0.8,
     blurredOpacity: 0.8,
+    animationDuration: 150,
     containerPadding: 30,
     pageSpacing: 10,
     vertical: false,
@@ -118,22 +120,22 @@ export default class CarouselPager extends Component {
           // New page needs to be shown (adjust opacity and scale)
           Animated.timing(this.state.viewsScale[page], {
             toValue: 1,
-            duration: 150
+            duration: this.props.animationDuration
           }).start();
 
           Animated.timing(this.state.viewsOpacity[page], {
             toValue: 1,
-            duration: 150
+            duration: this.props.animationDuration
           }).start();
 
           Animated.timing(this.state.viewsScale[this._currentPage], {
             toValue: this.props.blurredZoom,
-            duration: 150
+            duration: this.props.animationDuration
           }).start();
 
           Animated.timing(this.state.viewsOpacity[this._currentPage], {
             toValue: this.props.blurredOpacity,
-            duration: 150
+            duration: this.props.animationDuration
           }).start();
         }
 
@@ -141,7 +143,7 @@ export default class CarouselPager extends Component {
         let toValue = this._getPosForPage(page);
         Animated.timing(this.state.pos, {
           toValue: toValue,
-          duration: 150
+          duration: this.props.animationDuration
         }).start();
 
         this._lastPos = toValue;

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ initialPage | number | 0 | Initial page to display on render
 vertical | boolean | false | Set to `true` if carousel should be vertical
 blurredZoom | number | 0.8 | Zoom (number between 0 and 1) to apply to blurred pages
 blurredOpacity | number | 0.8 | Opacity (number between 0 and 1) to apply to blurred pages
+animationDuration | number | 150 | Animation duration between page changes
 containerPadding | number | 30 | Container padding (used to display part of preceding and following pages)
 pageSpacing | number | 10 | Space between pages
 pageStyle | object | null | Style to apply to each page


### PR DESCRIPTION
I found that the 150 default for animating between pages was a little fast, so I created a property to adjust the duration. 