### PR TITLE
Add scrollThreshold prop for a  min diff required to do scrolling

### DIFF
--- a/CarouselPager.js
+++ b/CarouselPager.js
@@ -20,7 +20,7 @@ export default class CarouselPager extends Component {
     onPageChange: PropTypes.func,
     deltaDelay: PropTypes.number,
     children: PropTypes.array.isRequired,
-    scrollSensitive: PropTypes.number
+    scrollThreshold: PropTypes.number
   }
 
   static defaultProps = {
@@ -32,7 +32,7 @@ export default class CarouselPager extends Component {
     pageSpacing: 10,
     vertical: false,
     deltaDelay: 0,
-    scrollSensitive: 0,
+    scrollThreshold: 0,
     onPageChange: () => {},
   }
 
@@ -187,7 +187,7 @@ export default class CarouselPager extends Component {
         const diff = gestureState['d' + suffix]
         this._lastPos += diff;
 
-        if (Math.abs(diff) > this.props.scrollSensitive) {
+        if (Math.abs(diff) > this.props.scrollThreshold) {
           let page = this._getPageForOffset(this._lastPos, diff);
           this.animateToPage(page);
         }

--- a/CarouselPager.js
+++ b/CarouselPager.js
@@ -19,7 +19,8 @@ export default class CarouselPager extends Component {
     pageStyle: PropTypes.object,
     onPageChange: PropTypes.func,
     deltaDelay: PropTypes.number,
-    children: PropTypes.array.isRequired
+    children: PropTypes.array.isRequired,
+    scrollSensitive: PropTypes.number
   }
 
   static defaultProps = {
@@ -31,6 +32,7 @@ export default class CarouselPager extends Component {
     pageSpacing: 10,
     vertical: false,
     deltaDelay: 0,
+    scrollSensitive: 0,
     onPageChange: () => {},
   }
 
@@ -182,9 +184,13 @@ export default class CarouselPager extends Component {
       onPanResponderTerminationRequest: (evt, gestureState) => true,
       onPanResponderRelease: (evt, gestureState) => {
         let suffix = this.props.vertical ? 'y' : 'x';
-        this._lastPos += gestureState['d' + suffix];
-        let page = this._getPageForOffset(this._lastPos, gestureState['d' + suffix]);
-        this.animateToPage(page);
+        const diff = gestureState['d' + suffix]
+        this._lastPos += diff;
+
+        if (Math.abs(diff) > this.props.scrollSensitive) {
+          let page = this._getPageForOffset(this._lastPos, diff);
+          this.animateToPage(page);
+        }
       },
       onPanResponderTerminate: (evt, gestureState) => {
       },

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ containerPadding | number | 30 | Container padding (used to display part of prec
 pageSpacing | number | 10 | Space between pages
 pageStyle | object | null | Style to apply to each page
 onPageChange | function | (page) => {} | When current page changes, call onPageChange with parameter
-scrollSensitive | number | 0 | Minimum differential (dx/dy) needed to do scrolling.
+scrollThreshold | number | 0 | Minimum differential (dx/dy) needed to do scrolling.
 ## Methods
 
 Name | propType | description

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ containerPadding | number | 30 | Container padding (used to display part of prec
 pageSpacing | number | 10 | Space between pages
 pageStyle | object | null | Style to apply to each page
 onPageChange | function | (page) => {} | When current page changes, call onPageChange with parameter
-
+scrollSensitive | number | 0 | Minimum differential (dx/dy) needed to do scrolling.
 ## Methods
 
 Name | propType | description


### PR DESCRIPTION
There's an issue when a device has a high sensitivity (e.g Samsung S8), it causes scrolling with just tapping, so it's needed add a gap.